### PR TITLE
Check if area delete button exists before remove

### DIFF
--- a/jquery.selectareas.js
+++ b/jquery.selectareas.js
@@ -424,7 +424,9 @@
                 $.each($resizeHandlers, function(card, $handler) {
                     $handler.remove();
                 });
-                $btDelete.remove();
+                if($btDelete){
+                    $btDelete.remove();    
+                } 
                 parent._remove(id);
                 fireEvent("changed");
             },


### PR DESCRIPTION
If allowDelete is set to false .remove() will fail because $btDelete is undefined.
