### PR TITLE
fix: aspect-ratio in Chromium, clear $image events when destroy

### DIFF
--- a/jquery.selectareas.js
+++ b/jquery.selectareas.js
@@ -474,7 +474,7 @@
             .addClass("select-areas-background-area")
             .css({
                 background : "#fff url(" + $image.attr("src") + ") no-repeat",
-                backgroundSize : $image.width() + "px",
+                backgroundSize : $image.width() + "px " + $image.height() + 'px',
                 position : "absolute"
             })
             .insertAfter($outline);
@@ -774,6 +774,7 @@
         this.$trigger.remove();
         this.$image.css("width", "").css("position", "").unwrap();
         this.$image.removeData("mainImageSelectAreas");
+        this.$image.off('changing changed loaded');
     };
 
     $.imageSelectAreas.prototype.areas = function () {


### PR DESCRIPTION
In the Chromium builtin by Electron, `background-image` won't keep aspect-ratio when scaling by width. Setting both width and height (via `background-size`) fixes this behavior.

Events like `onChanging` and `onChanged` are still firing after `.destroy()` was called. That means if we destroy and initiate (by calling `$("#mypic").selectAreas()`) the second time, the `onChanged` will be called twice for a single selection.